### PR TITLE
fix: remove automatic restart timeout for congratulations modal

### DIFF
--- a/TECHNICAL_DEBT.md
+++ b/TECHNICAL_DEBT.md
@@ -84,6 +84,7 @@ This document tracks technical debt in the Timeline Game project, helping us pri
 | FE-017 | Memory Leaks in Timers | ✅ **RESOLVED** - Fixed setTimeout cleanup in Feedback component. Verified AnimationControls already had proper setInterval cleanup. Documented timer usage patterns for future maintenance. | Medium | 1 day | $(date) | **Resolved** |
 | FE-018 | Settings Page Test Coverage | Several modal/ARIA/keyboard tests were removed due to persistent test environment issues and need to be re-implemented for full coverage. | Low | 0.5 days | $(date) | In Progress |
 | FE-019 | React Router Import Issue | ✅ **RESOLVED** - Fixed white screen issue by removing unsupported UNSAFE_future import from react-router-dom. Simplified Router configuration and resolved build error that was preventing application from loading. | High | 0.5 days | $(date) | **Resolved** |
+| FE-021 | Congratulations Modal Auto-Close | ✅ **RESOLVED** - Removed automatic restart timeout that was closing the congratulations modal after 3 seconds. Now the modal stays open until the user manually chooses to restart or go home, providing better user experience and control. | Medium | 0.5 days | $(date) | **Resolved** |
 
 ### Backend Technical Debt
 

--- a/timeline-frontend/src/hooks/useGameState.js
+++ b/timeline-frontend/src/hooks/useGameState.js
@@ -602,16 +602,14 @@ export const useGameState = () => {
             }, 3000);
           }
 
-          // If game is won, show feedback and restart after delay
+          // If game is won, show feedback (no automatic restart)
           if (isGameWon) {
             // Clear any existing restart timeout
             if (restartTimeoutRef.current) {
               clearTimeout(restartTimeoutRef.current);
+              restartTimeoutRef.current = null;
             }
-            // Set new restart timeout
-            restartTimeoutRef.current = setTimeout(() => {
-              restartGame();
-            }, 3000);
+            // Don't automatically restart - let user choose when to restart
           }
 
           return {


### PR DESCRIPTION
- Remove automatic restart timeout that was closing congratulations modal after 3 seconds
- Now modal stays open until user manually chooses to restart or go home
- Improves user experience by giving players time to celebrate and review stats
- Update technical debt documentation to reflect the fix

Fixes: Congratulations modal auto-closing issue
Impact: Better user experience for game completion