### PR TITLE
Refactor: Clean up settings page UI

### DIFF
--- a/timeline-frontend/src/pages/Settings.jsx
+++ b/timeline-frontend/src/pages/Settings.jsx
@@ -279,31 +279,7 @@ const SettingsContent = () => {
 
 
 
-          {/* Settings Preview */}
-          <div className="settings-preview">
-            <h3>⚡ Current Settings</h3>
-            <div className="preview-grid">
-              <div className="preview-item">
-                <span className="preview-label">Difficulty:</span>
-                <span className="preview-value">
-                  {settings.difficulty || 'medium'}
-                </span>
-              </div>
-              <div className="preview-item">
-                <span className="preview-label">Cards:</span>
-                <span className="preview-value">{settings.cardCount || 5}</span>
-              </div>
-              <div className="preview-item">
-                <span className="preview-label">Categories:</span>
-                <span className="preview-value">
-                  {settings.categories && settings.categories.length > 0
-                    ? settings.categories.join(', ')
-                    : 'All categories'}
-                </span>
-              </div>
 
-            </div>
-          </div>
 
           {/* Action Buttons */}
           <div className="settings-actions">

--- a/timeline-frontend/src/pages/Settings.jsx
+++ b/timeline-frontend/src/pages/Settings.jsx
@@ -296,9 +296,7 @@ const SettingsContent = () => {
               🔄 Reset to Defaults
             </button>
 
-            <a href="/game" className="btn btn-success">
-              🎮 Start Game
-            </a>
+
           </div>
 
           {/* Help Section */}

--- a/timeline-frontend/src/pages/Settings.jsx
+++ b/timeline-frontend/src/pages/Settings.jsx
@@ -299,56 +299,7 @@ const SettingsContent = () => {
 
           </div>
 
-          {/* Help Section */}
-          <div className="settings-help">
-            <h3>❓ Need Help?</h3>
-            <div className="help-grid">
-              <div className="help-item">
-                <h4>Difficulty Levels</h4>
-                <ul>
-                  <li>
-                    <strong>Easy:</strong> Relaxed gameplay with generous time
-                    limits and hints
-                  </li>
-                  <li>
-                    <strong>Medium:</strong> Balanced challenge with moderate
-                    time pressure
-                  </li>
-                  <li>
-                    <strong>Hard:</strong> Challenging gameplay with strict time
-                    limits
-                  </li>
-                  <li>
-                    <strong>Expert:</strong> Maximum challenge with minimal
-                    assistance
-                  </li>
-                </ul>
-              </div>
-              <div className="help-item">
-                <h4>Categories</h4>
-                <ul>
-                  <li>
-                    <strong>History:</strong> Wars, politics, social events
-                  </li>
-                  <li>
-                    <strong>Science:</strong> Discoveries, inventions, research
-                  </li>
-                  <li>
-                    <strong>Technology:</strong> Computing, engineering,
-                    innovations
-                  </li>
-                  <li>
-                    <strong>Space:</strong> Space exploration, astronomy
-                  </li>
-                  <li>
-                    <strong>Aviation:</strong> Flight history, aircraft
-                    development
-                  </li>
-                </ul>
-              </div>
 
-            </div>
-          </div>
         </div>
       </div>
 

--- a/timeline-frontend/src/pages/Settings.test.jsx
+++ b/timeline-frontend/src/pages/Settings.test.jsx
@@ -172,16 +172,7 @@ describe('Settings Page', () => {
       });
     });
 
-    it('should render settings preview', async () => {
-      renderSettings();
 
-      await waitFor(() => {
-        expect(screen.getByText('⚡ Current Settings')).toBeInTheDocument();
-        expect(screen.getByText('Difficulty:')).toBeInTheDocument();
-        expect(screen.getByText('Cards:')).toBeInTheDocument();
-        expect(screen.getByText('Categories:')).toBeInTheDocument();
-      });
-    });
   });
 
   describe('Loading States', () => {

--- a/timeline-frontend/src/pages/Settings.test.jsx
+++ b/timeline-frontend/src/pages/Settings.test.jsx
@@ -167,8 +167,6 @@ describe('Settings Page', () => {
       await waitFor(() => {
         expect(screen.getByText('💾 Save Settings')).toBeInTheDocument();
         expect(screen.getByText('🔄 Reset to Defaults')).toBeInTheDocument();
-
-        expect(screen.getByText('🎮 Start Game')).toBeInTheDocument();
       });
     });
 


### PR DESCRIPTION
## Summary

This PR removes several UI elements from the settings page to create a cleaner, more focused interface:

### Changes Made:
- ❌ Removed '♿ Accessibility' section and all related settings/tests
- ❌ Removed '⚡ Performance' section and all related settings/tests  
- ❌ Removed '⚡ Current Settings' preview section
- ❌ Removed '🎮 Start Game' button
- ❌ Removed '❓ Need Help?' explanations section

### Benefits:
- 🎯 More focused settings interface
- 🧹 Cleaner codebase with reduced complexity
- 📱 Better mobile experience with less clutter
- 🚀 Improved maintainability

### Testing:
- ✅ All tests pass
- ✅ No breaking changes to core functionality
- ✅ Settings management still works correctly

The settings page now contains only the essential game settings (difficulty, card count, categories) and action buttons (save, reset), providing a streamlined user experience.