### PR TITLE
fix: correct API response structure access in CardManager

### DIFF
--- a/timeline-frontend/src/components/admin/CardManager/CardManager.jsx
+++ b/timeline-frontend/src/components/admin/CardManager/CardManager.jsx
@@ -67,10 +67,10 @@ const CardManager = () => {
       const response = await gameAPI.getAdminCards(params.toString());
       const data = response.data;
 
-      setCards(data.cards);
+      setCards(data.data.cards);
       setPagination(prev => ({
         ...prev,
-        total: data.pagination.total
+        total: data.data.pagination.total
       }));
     } catch (err) {
       setError('Failed to load cards: ' + err.message);

--- a/timeline-frontend/src/pages/Admin.test.jsx
+++ b/timeline-frontend/src/pages/Admin.test.jsx
@@ -54,8 +54,11 @@ describe('Admin Page', () => {
     // Mock successful API response
     gameAPI.getAdminCards.mockResolvedValue({
       data: {
-        cards: mockCards,
-        pagination: mockPagination
+        success: true,
+        data: {
+          cards: mockCards,
+          pagination: mockPagination
+        }
       }
     });
   });
@@ -167,8 +170,11 @@ describe('Admin Page', () => {
     test('shows empty state when no cards are found', async () => {
       gameAPI.getAdminCards.mockResolvedValue({
         data: {
-          cards: [],
-          pagination: { total: 0, limit: 20, offset: 0, hasMore: false }
+          success: true,
+          data: {
+            cards: [],
+            pagination: { total: 0, limit: 20, offset: 0, hasMore: false }
+          }
         }
       });
       


### PR DESCRIPTION
- Fix data.pagination.total access to use data.data.pagination.total
- Update CardManager to correctly handle nested API response structure
- Fix Admin test mocks to match actual API response format
- Resolves 'can\'t access property "total", data.pagination is undefined' error

The backend API returns data in nested structure:
{
  success: true, data: { cards: [...], pagination: { total, limit, offset, hasMore } } }

Frontend was incorrectly accessing data.pagination instead of data.data.pagination.